### PR TITLE
Fixing Light/Dark Solarized Theme setting in Update-Link / Get-Link

### DIFF
--- a/Get-Link.ps1
+++ b/Get-Link.ps1
@@ -308,6 +308,8 @@ namespace Huddled.Interop
             _ConsoleProperties.dwScreenBufferSize.X = 120;
             _ConsoleProperties.dwScreenBufferSize.Y = 8000;
 
+            _ConsoleProperties.bQuickEdit = true;
+
             _ConsoleProperties.bAutoPosition = true;
 
             for (int i = 0; i < 16; i++)

--- a/Get-Link.ps1
+++ b/Get-Link.ps1
@@ -293,13 +293,23 @@ namespace Huddled.Interop
             ((IPersistFile)_ShellLink).Save(Path, true);
          }
 
-         // Initialize default Console Properties (TODO: Fix this bug too)
+         // TODO: Don't fake it, pull these values from the Registry
+         // Initialize default Console Properties
          if (_ConsoleProperties.dwSignature != 0xA0000002)
          {
             _ConsoleProperties = new NT_CONSOLE_PROPS();
             _ConsoleProperties.cbSize = Marshal.SizeOf(_ConsoleProperties);
             _ConsoleProperties.dwSignature = 0xA0000002;
             _ConsoleProperties.ColorTable = new uint[16];
+
+            _ConsoleProperties.dwWindowSize.X = 120;
+            _ConsoleProperties.dwWindowSize.Y = 30;
+
+            _ConsoleProperties.dwScreenBufferSize.X = 120;
+            _ConsoleProperties.dwScreenBufferSize.Y = 8000;
+
+            _ConsoleProperties.bAutoPosition = true;
+
             for (int i = 0; i < 16; i++)
             {
                _ConsoleProperties.ColorTable[i] = 0xffffffff;
@@ -406,18 +416,14 @@ namespace Huddled.Interop
 
       public void SetScreenBufferSize(short x, short y)
       {
-         COORD c = new COORD();
-         c.X = x;
-         c.Y = y;
-         _ConsoleProperties.dwScreenBufferSize = c;
+         _ConsoleProperties.dwScreenBufferSize.X = x;
+         _ConsoleProperties.dwScreenBufferSize.Y = y;
       }
 
       public void SetWindowSize(short x, short y)
       {
-         COORD c = new COORD();
-         c.X = x;
-         c.Y = y;
-         _ConsoleProperties.dwWindowSize = c;
+         _ConsoleProperties.dwWindowSize.X = x;
+         _ConsoleProperties.dwWindowSize.Y = y;
       }
 
       public uint CommandHistoryBufferSize
@@ -439,7 +445,6 @@ namespace Huddled.Interop
             _ScreenFill &= 0x000f;
             _ScreenFill += (ushort)(value << 4);
          }
-
       }
 
       public byte ScreenTextColor
@@ -449,7 +454,6 @@ namespace Huddled.Interop
             _ScreenFill &= 0x00f0;
             _ScreenFill += value;
          }
-
       }
 
       public byte PopUpBackgroundColor

--- a/Get-Link.ps1
+++ b/Get-Link.ps1
@@ -436,7 +436,7 @@ namespace Huddled.Interop
       {
          set
          {
-            _ScreenFill &= 0x00ff;
+            _ScreenFill &= 0x000f;
             _ScreenFill += (ushort)(value << 4);
          }
 
@@ -446,7 +446,7 @@ namespace Huddled.Interop
       {
          set
          {
-            _ScreenFill &= 0xff00;
+            _ScreenFill &= 0x00f0;
             _ScreenFill += value;
          }
 
@@ -456,7 +456,7 @@ namespace Huddled.Interop
       {
          set
          {
-            _PopUpFill &= 0x00ff;
+            _PopUpFill &= 0x000f;
             _PopUpFill += (ushort)(value << 4);
          }
       }
@@ -465,7 +465,7 @@ namespace Huddled.Interop
       {
          set
          {
-            _PopUpFill &= 0xff00;
+            _PopUpFill &= 0x00f0;
             _PopUpFill += value;
          }
       }

--- a/Update-Link.ps1
+++ b/Update-Link.ps1
@@ -1,6 +1,16 @@
-param([Parameter(Mandatory=$True)][ValidateScript({Test-Path $_})][string]$Path, [string]$Theme)
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateScript({Test-Path $_})]
+    [string]$Path,
+
+    [Parameter()]
+    [ValidateSet('Light','Dark')]
+    [string]$Theme
+)
 
 $lnk = & ("$PSScriptRoot\Get-Link.ps1") $Path
+
+# Set Common Solarized Colors
 $lnk.ConsoleColors[0]="#002b36"
 $lnk.ConsoleColors[8]="#073642"
 $lnk.ConsoleColors[2]="#586e75"
@@ -17,7 +27,8 @@ $lnk.ConsoleColors[5]="#6c71c4"
 $lnk.ConsoleColors[9]="#268bd2"
 $lnk.ConsoleColors[11]="#2aa198"
 $lnk.ConsoleColors[10]="#859900"
-# This defines dark, swap Screen and PopUp for light
+
+# Set Light/Dark Theme-Specific Colors
 if ($Theme -eq "Dark") {
     $lnk.PopUpBackgroundColor=0xf
     $lnk.PopUpTextColor=0x6
@@ -29,5 +40,7 @@ if ($Theme -eq "Dark") {
     $lnk.ScreenBackgroundColor=0xf
     $lnk.ScreenTextColor=0x6
 }
+
 $lnk.Save()
-Write-Host "Updated $Path"
+
+Write-Host "Updated $Path to Solarized - $Theme"

--- a/Update-Link.ps1
+++ b/Update-Link.ps1
@@ -5,7 +5,7 @@ param(
 
     [Parameter()]
     [ValidateSet('Light','Dark')]
-    [string]$Theme
+    [string]$Theme = 'Dark'
 )
 
 $lnk = & ("$PSScriptRoot\Get-Link.ps1") $Path


### PR DESCRIPTION
TBBIe pointed out the issue with the Light/Dark Theme.  I took his suggested change, did some testing and found issues where my window would be 1x1 after running Update-Link.

Traced that to lack of defaults for size, buffer, etc. and added "intelligent" defaults for those.  The right fix will be to pull the correct values in the same way that windows does when processing the lnk (I believe they come from the registry!)

I also tweaked the "Theme" argument to make it more user-friendly.

(and some spacing/comment stuff)